### PR TITLE
Fix Latest Prices UI snapshot parsing and rendering

### DIFF
--- a/InsaDemoRealtimePrices/wwwroot/index.html
+++ b/InsaDemoRealtimePrices/wwwroot/index.html
@@ -169,12 +169,28 @@
             row.querySelector('[data-col="feedEpoch"]').textContent = tick.t ?? tick.feedEpochMs ?? "";
         }
 
+        function renderSnapshot(ticks) {
+            if (!Array.isArray(ticks)) {
+                return;
+            }
+
+            for (const tick of ticks) {
+                upsertRow(tick);
+            }
+        }
+
         async function loadApiSnapshot() {
             try {
                 const response = await fetch("/api/prices/GetPrices");
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+
                 const json = await response.json();
+                const ticks = json.currentSnapshot ?? json.CurrentSnapshot ?? json.prices ?? json.Prices ?? [];
+                renderSnapshot(ticks);
                 apiSnapshotEl.textContent = JSON.stringify(json, null, 2);
-                log(`Loaded API snapshot (${json.prices?.length ?? 0} prices).`);
+                log(`Loaded API snapshot (${ticks.length} prices).`);
             } catch (err) {
                 log(`API snapshot failed: ${err}`);
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix test client API snapshot parsing to read `currentSnapshot` (with fallbacks for legacy field names)
- populate the **Latest Prices** table from the API snapshot response
- harden feed ingestion to parse multiple payload shapes:
  - single object ticks
  - arrays of ticks
  - wrapped payloads under `data`
  - quote (`ap/as/bp/bs`) and trade (`p/v`) style fields
- set default websocket feed config to known-working demo stream:
  - `wss://ws.eodhistoricaldata.com/ws/us-quote?api_token=demo`
  - symbols: `AAPL,MSFT,TSLA`
- add backend warning logs for non-tick feed status frames (for example auth/403 errors), so feed failures are visible immediately

## Root cause observed
- upstream websocket with previous configured token returned `{"status":403,"message":"Server error"}`
- with `api_token=demo`, feed authorizes and streams quote ticks normally

## Validation
- direct websocket probe from this environment:
  - previous token: receives 403 status frame and no ticks
  - demo token: receives `status_code:200` and continuous tick messages for AAPL/MSFT/TSLA
- static code path verification completed for:
  - ingest -> snapshot store -> SignalR `PriceUpdated`
  - API snapshot -> UI table rendering path

## Notes
- existing SignalR contract is unchanged (`GetPrices`, `PriceSnapshot`, `PriceUpdated`)
- if you set your own token, provide it via `EodPriceFeed:WebSocketUrl` and choose symbols your plan allows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6982e7b-6768-457c-97bb-3bb9b8805b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6982e7b-6768-457c-97bb-3bb9b8805b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

